### PR TITLE
[PR] 원자재 사용관리

### DIFF
--- a/httpTest/MaterialUsageTest.http
+++ b/httpTest/MaterialUsageTest.http
@@ -11,3 +11,6 @@ Content-Type: application/json
   "workOrderStatusType": "IN_PROGRESS",
   "orderedQuantity": 444
 }
+
+### 전체조회 테스트
+GET http://localhost:8001/api/v1/material/use

--- a/httpTest/MaterialUsageTest.http
+++ b/httpTest/MaterialUsageTest.http
@@ -15,5 +15,18 @@ Content-Type: application/json
 ### 전체조회 테스트
 GET http://localhost:8001/api/v1/material/use
 
-### 상세조회 테스ㅡ
+### 상세조회 테스트
 GET http://localhost:8001/api/v1/material/use/1
+
+### 재고-사용 추가 테스트(전달목록으로 이동)
+POST http://localhost:8001/api/v1/material/stock-usage
+Content-Type: application/json
+
+{
+  "stockCode": 20,
+  "usageCode": 1,
+  "usedQuantity": 10
+}
+
+### 재고-사용목록 조회(usage코드로)
+GET http://localhost:8001/api/v1/material/stock-usage/1

--- a/httpTest/MaterialUsageTest.http
+++ b/httpTest/MaterialUsageTest.http
@@ -14,3 +14,6 @@ Content-Type: application/json
 
 ### 전체조회 테스트
 GET http://localhost:8001/api/v1/material/use
+
+### 상세조회 테스ㅡ
+GET http://localhost:8001/api/v1/material/use/1

--- a/httpTest/MaterialUsageTest.http
+++ b/httpTest/MaterialUsageTest.http
@@ -23,10 +23,17 @@ POST http://localhost:8001/api/v1/material/stock-usage
 Content-Type: application/json
 
 {
-  "stockCode": 20,
+  "stockCode": 31,
   "usageCode": 1,
   "usedQuantity": 10
 }
 
 ### 재고-사용목록 조회(usage코드로)
 GET http://localhost:8001/api/v1/material/stock-usage/1
+
+### 전달 취소
+DELETE http://localhost:8001/api/v1/material/stock-usage?stockUsageCode=4
+
+### 전달여부 변경
+PUT http://localhost:8001/api/v1/material/stock-usage?stockUsageCode=5
+

--- a/httpTest/MaterialUsageTest.http
+++ b/httpTest/MaterialUsageTest.http
@@ -1,0 +1,13 @@
+### usage 자동등록 테스트
+POST http://localhost:8001/api/v1/production/work-order
+Content-Type: application/json
+
+{
+  "workWrittenDate": "2024-06-05",
+  "workOrderDate": "2024-06-04",
+  "lineCode": 3,
+  "employeeCode": 1,
+  "productCode": 1,
+  "workOrderStatusType": "IN_PROGRESS",
+  "orderedQuantity": 444
+}

--- a/src/main/java/com/hmdandelion/project_1410002/auth/config/SecurityConfig.java
+++ b/src/main/java/com/hmdandelion/project_1410002/auth/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                     auth.requestMatchers("/api/v1/estimates/**").hasAuthority("SALES");
                     auth.requestMatchers("/api/v1/orders/**").hasAuthority("SALES");
                     auth.requestMatchers("/api/v1/returns/**").hasAuthority("SALES");
-                    auth.anyRequest().permitAll(); //TODO 테스트용으로 변경하였음
+                    auth.anyRequest().authenticated();
                 })
                 .addFilterBefore(customAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter(), BasicAuthenticationFilter.class)

--- a/src/main/java/com/hmdandelion/project_1410002/auth/config/SecurityConfig.java
+++ b/src/main/java/com/hmdandelion/project_1410002/auth/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                     auth.requestMatchers("/api/v1/estimates/**").hasAuthority("SALES");
                     auth.requestMatchers("/api/v1/orders/**").hasAuthority("SALES");
                     auth.requestMatchers("/api/v1/returns/**").hasAuthority("SALES");
-                    auth.anyRequest().authenticated();
+                    auth.anyRequest().permitAll(); //TODO 테스트용으로 변경하였음
                 })
                 .addFilterBefore(customAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter(), BasicAuthenticationFilter.class)

--- a/src/main/java/com/hmdandelion/project_1410002/common/exception/type/ExceptionCode.java
+++ b/src/main/java/com/hmdandelion/project_1410002/common/exception/type/ExceptionCode.java
@@ -18,6 +18,7 @@ public enum ExceptionCode {
     NOT_FOUND_MATERIAL_NAME(3402, "자재 이름에 해당하는 스톡이 존재하지 않습니다." ),
     NOT_FOUND_WAREHOUSE_CODE(3403,"창고 코드에 맞는 창고가 존재하지 않습니다" ),
     NOT_FOUND_SPEC_CODE(3404,"스펙 코드에 맞는 스펙이 존재하지 않습니다." ),
+    NOT_FOUND_USAGE_CODE(3405,"사용코드에 맞는 사용이 존재하지 않습니다." ),
     NOT_FOUND_BOM_CODE(3501,"BOM 코드에 맞는 BOM이 존재하지 않습니다."),
     NOT_FOUND_STORAGE_CODE(3502,"저장 이력 코드가 존재하지 않습니다."),
     NOT_FOUND_PRODUCTION_CODE(3600, "상품 코드에 해당하는 생산 보고서가 존재하지 않습니다."),
@@ -55,6 +56,7 @@ public enum ExceptionCode {
     NOT_FOUND_REFRESH_TOKEN(9901, "리프레시 토큰이 유효하지 않습니다."),
     UNAUTHORIZED(9902, "인증되지 않은 요청입니다."),
     ACCESS_DENIED(9903, "인가되지 않은 요청입니다.");
+
 
 
     private final int code;

--- a/src/main/java/com/hmdandelion/project_1410002/common/exception/type/ExceptionCode.java
+++ b/src/main/java/com/hmdandelion/project_1410002/common/exception/type/ExceptionCode.java
@@ -36,6 +36,7 @@ public enum ExceptionCode {
     NO_CONTENTS_M_ORDERS(4401,"찾으시는 원자재 주문이 존재하지 않습니다." ),
     No_CONTENTS_CLIENT_CODE(4402,"조건에 맞는 거래처가 존재하지 않습니다." ),
     No_CONTENTS_M_ORDER_TODAY(4403,"금일 입고 예정인 주문이 없습니다." ),
+    NO_CONTENTS_MATERIAL_USE(4404,"조건에 맞는 원자재 사용이 존재하지 않습니다." ),
 
     BAD_REQUEST_ORDER_EXIST_CLIENT(6100, "주문건이 존재하는 거래처는 삭제할 수 없습니다."),
     BAD_REQUEST_ORDERED_ESTIMATE(6200, "주문이 진행된 견적은 삭제할 수 없습니다."),

--- a/src/main/java/com/hmdandelion/project_1410002/common/exception/type/ExceptionCode.java
+++ b/src/main/java/com/hmdandelion/project_1410002/common/exception/type/ExceptionCode.java
@@ -43,6 +43,7 @@ public enum ExceptionCode {
     BAD_REQUEST_ORDERED_ESTIMATE(6200, "주문이 진행된 견적은 삭제할 수 없습니다."),
     BAD_REQUEST_DEADLINE_PASSED(6201, "마감일자가 지난 견적은 주문으로 전환할 수 없습니다."),
     BAD_REQUEST_NO_OPTIONS(6400, "스펙 삭제에 필요한 정보를 제공하지 않았습니다." ),
+    BAD_REQUEST_INSUFFICIENT_QUANTITY(6401,"사용하려는 재고보다 실수량이 부족합니다" ),
     BAD_REQUEST_MORE_QUANTITY(6500,"보관 중인 재고가 재고 수량보다 큽니다."),
     BAD_REQUEST_MIN_QUANTITY(6500,"최소 수량이 최대 수량보다 큽니다."),
     BAD_REQUEST_DELETED_STOCK(6501,"삭제 된 재고 정보입니다."),
@@ -57,6 +58,7 @@ public enum ExceptionCode {
     NOT_FOUND_REFRESH_TOKEN(9901, "리프레시 토큰이 유효하지 않습니다."),
     UNAUTHORIZED(9902, "인증되지 않은 요청입니다."),
     ACCESS_DENIED(9903, "인가되지 않은 요청입니다.");
+
 
 
 

--- a/src/main/java/com/hmdandelion/project_1410002/inventory/domian/entity/material/MaterialStock.java
+++ b/src/main/java/com/hmdandelion/project_1410002/inventory/domian/entity/material/MaterialStock.java
@@ -65,7 +65,11 @@ public class MaterialStock {
     }
 
     public void modifyFrom(MaterialStockModifyRequest request, Warehouse warehouse) {
-        this.actualQuantity = request.getActualQuantity();
+        if (request.getActualQuantity() < 0) {
+            this.actualQuantity = actualQuantity - request.getActualQuantity();
+        } else {
+            this.actualQuantity = request.getActualQuantity();
+        }
         this.modificationReason = request.getModificationReason();
         this.warehouse = warehouse;
     }

--- a/src/main/java/com/hmdandelion/project_1410002/inventory/domian/entity/material/MaterialStock.java
+++ b/src/main/java/com/hmdandelion/project_1410002/inventory/domian/entity/material/MaterialStock.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/hmdandelion/project_1410002/inventory/domian/entity/material/MaterialStock.java
+++ b/src/main/java/com/hmdandelion/project_1410002/inventory/domian/entity/material/MaterialStock.java
@@ -1,6 +1,8 @@
 package com.hmdandelion.project_1410002.inventory.domian.entity.material;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.hmdandelion.project_1410002.common.exception.BadRequestException;
+import com.hmdandelion.project_1410002.common.exception.type.ExceptionCode;
 import com.hmdandelion.project_1410002.inventory.domian.entity.warehouse.Warehouse;
 import com.hmdandelion.project_1410002.inventory.domian.type.StockDivision;
 import com.hmdandelion.project_1410002.inventory.dto.material.request.MaterialStockCreateRequest;
@@ -67,6 +69,9 @@ public class MaterialStock {
     public void modifyFrom(MaterialStockModifyRequest request, Warehouse warehouse) {
         if (request.getActualQuantity() < 0) {
             this.actualQuantity = actualQuantity - request.getActualQuantity();
+            if (this.actualQuantity < 0) {
+                throw new BadRequestException(ExceptionCode.BAD_REQUEST_INSUFFICIENT_QUANTITY);
+            }
         } else {
             this.actualQuantity = request.getActualQuantity();
         }

--- a/src/main/java/com/hmdandelion/project_1410002/inventory/domian/entity/material/MaterialStock.java
+++ b/src/main/java/com/hmdandelion/project_1410002/inventory/domian/entity/material/MaterialStock.java
@@ -7,6 +7,7 @@ import com.hmdandelion.project_1410002.inventory.domian.entity.warehouse.Warehou
 import com.hmdandelion.project_1410002.inventory.domian.type.StockDivision;
 import com.hmdandelion.project_1410002.inventory.dto.material.request.MaterialStockCreateRequest;
 import com.hmdandelion.project_1410002.inventory.dto.material.request.MaterialStockModifyRequest;
+import com.hmdandelion.project_1410002.production.domain.entity.material.StockUsage;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -67,16 +68,20 @@ public class MaterialStock {
     }
 
     public void modifyFrom(MaterialStockModifyRequest request, Warehouse warehouse) {
-        if (request.getActualQuantity() < 0) {
-            this.actualQuantity = actualQuantity - request.getActualQuantity();
-            if (this.actualQuantity < 0) {
-                throw new BadRequestException(ExceptionCode.BAD_REQUEST_INSUFFICIENT_QUANTITY);
-            }
-        } else {
-            this.actualQuantity = request.getActualQuantity();
-        }
+
+        this.actualQuantity = request.getActualQuantity();
+
         this.modificationReason = request.getModificationReason();
         this.warehouse = warehouse;
+    }
+
+    public void modifyWithStockUsage(int usedQuantity, String reson) {
+
+        this.actualQuantity = (int)(actualQuantity - usedQuantity);
+        if (this.actualQuantity < 0) {
+            throw new BadRequestException(ExceptionCode.BAD_REQUEST_INSUFFICIENT_QUANTITY);
+        }
+        this.modificationReason = reson;
     }
 }
 

--- a/src/main/java/com/hmdandelion/project_1410002/inventory/domian/repository/material/stock/MaterialStockRepoCustom.java
+++ b/src/main/java/com/hmdandelion/project_1410002/inventory/domian/repository/material/stock/MaterialStockRepoCustom.java
@@ -10,4 +10,6 @@ public interface MaterialStockRepoCustom {
     List<MaterialStock> searchMaterialStock(Pageable pageable, String materialName, Long warehouseCode, Long specCategoryCode);
 
     MaterialStock getStockByCode(Long stockCode);
+
+    List<Long> searchMaterialStockByMaterialName(String materialName);
 }

--- a/src/main/java/com/hmdandelion/project_1410002/inventory/domian/repository/material/stock/MaterialStockRepoCustomImpl.java
+++ b/src/main/java/com/hmdandelion/project_1410002/inventory/domian/repository/material/stock/MaterialStockRepoCustomImpl.java
@@ -54,4 +54,14 @@ public class MaterialStockRepoCustomImpl implements MaterialStockRepoCustom {
                 .fetchFirst();
     }
 
+    @Override
+    public List<Long> searchMaterialStockByMaterialName(String materialName) {
+        QMaterialStock materialStock = QMaterialStock.materialStock;
+        return queryFactory.select(materialStock.stockCode)
+                           .from(materialStock)
+                           .where(materialStock.materialSpec.materialName.contains(materialName))
+                           .fetch();
+
+    }
+
 }

--- a/src/main/java/com/hmdandelion/project_1410002/inventory/dto/product/dto/BomDTO.java
+++ b/src/main/java/com/hmdandelion/project_1410002/inventory/dto/product/dto/BomDTO.java
@@ -1,0 +1,23 @@
+package com.hmdandelion.project_1410002.inventory.dto.product.dto;
+
+import com.hmdandelion.project_1410002.inventory.domian.entity.product.Bom;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@RequiredArgsConstructor
+public class BomDTO {
+    private final String materialName;
+    private final String categoryName;
+    private final Long quantity;
+
+    public static BomDTO from(Bom bom) {
+        return new BomDTO(
+                bom.getMaterialSpec().getMaterialName(),
+                bom.getMaterialSpec().getCategory().getCategoryName(),
+                bom.getQuantity()
+        );
+    }
+}

--- a/src/main/java/com/hmdandelion/project_1410002/inventory/service/MaterialStockService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/inventory/service/MaterialStockService.java
@@ -14,7 +14,6 @@ import com.hmdandelion.project_1410002.inventory.dto.material.dto.MaterialStockS
 import com.hmdandelion.project_1410002.inventory.dto.material.request.MaterialStockCreateRequest;
 import com.hmdandelion.project_1410002.inventory.dto.material.request.MaterialStockModifyRequest;
 import com.hmdandelion.project_1410002.inventory.dto.material.response.MaterialStockResponse;
-import com.hmdandelion.project_1410002.production.domain.entity.material.StockUsage;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,9 +97,9 @@ public class MaterialStockService {
         return materialStockRepo.searchMaterialStockByMaterialName(materialName);
     }
 
-    public void modifyWithStockUsage(Long stockCode, int usedQuantity, String reson) {
+    public void modifyWithStockUsage(Long stockCode, int usedQuantity, String reason) {
         MaterialStock stock = materialStockRepo.getStockByCode(stockCode);
-        stock.modifyWithStockUsage(usedQuantity,reson);
+        stock.modifyWithStockUsage(usedQuantity, reason);
 
     }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/inventory/service/MaterialStockService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/inventory/service/MaterialStockService.java
@@ -14,6 +14,7 @@ import com.hmdandelion.project_1410002.inventory.dto.material.dto.MaterialStockS
 import com.hmdandelion.project_1410002.inventory.dto.material.request.MaterialStockCreateRequest;
 import com.hmdandelion.project_1410002.inventory.dto.material.request.MaterialStockModifyRequest;
 import com.hmdandelion.project_1410002.inventory.dto.material.response.MaterialStockResponse;
+import com.hmdandelion.project_1410002.production.domain.entity.material.StockUsage;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,5 +96,11 @@ public class MaterialStockService {
     public List<Long> searchMaterialStockByMaterialName(String materialName) {
 
         return materialStockRepo.searchMaterialStockByMaterialName(materialName);
+    }
+
+    public void modifyWithStockUsage(Long stockCode, int usedQuantity, String reson) {
+        MaterialStock stock = materialStockRepo.getStockByCode(stockCode);
+        stock.modifyWithStockUsage(usedQuantity,reson);
+
     }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/inventory/service/MaterialStockService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/inventory/service/MaterialStockService.java
@@ -87,4 +87,9 @@ public class MaterialStockService {
         stock.modifyFrom(request, warehouse);
         return stock.getStockCode();
     }
+
+    public List<Long> searchMaterialStockByMaterialName(String materialName) {
+
+        return materialStockRepo.searchMaterialStockByMaterialName(materialName);
+    }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/domain/entity/material/MaterialUsage.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/domain/entity/material/MaterialUsage.java
@@ -1,6 +1,7 @@
 package com.hmdandelion.project_1410002.production.domain.entity.material;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.hmdandelion.project_1410002.production.domain.entity.WorkOrder;
 import com.hmdandelion.project_1410002.production.domain.type.MaterialUsageStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -26,18 +27,22 @@ public class MaterialUsage {
     @LastModifiedDate
     private LocalDateTime usageDatetime;
     private Long employeeCode; //TODO 수정필
-    private Long workOrderCode; //TODO 수정필
+    //    private Long workOrderCode; //TODO 수정필
+    @ManyToOne
+    @JoinColumn(name = "work_order_code")
+    private WorkOrder workOrder;
+    @Enumerated(value = EnumType.STRING)
     private MaterialUsageStatus status;
 
-    public MaterialUsage(Long workOrderCode, LocalDateTime usageDatetime) {
-        this.workOrderCode = workOrderCode;
+    public MaterialUsage(WorkOrder workOrder, LocalDateTime usageDatetime) {
+        this.workOrder = workOrder;
         this.usageDatetime = usageDatetime;
         this.status = MaterialUsageStatus.READY;
     }
 
-    public static MaterialUsage of(Long workOrderCode, LocalDate workOrderDate) {
+    public static MaterialUsage of(WorkOrder workOrder) {
         return new MaterialUsage(
-                workOrderCode, workOrderDate.atStartOfDay()
+                workOrder, workOrder.getWorkOrderDate().atStartOfDay()
         );
     }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/domain/entity/material/MaterialUsage.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/domain/entity/material/MaterialUsage.java
@@ -6,8 +6,10 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Table(name = "tbl_material_usage")
@@ -21,8 +23,21 @@ public class MaterialUsage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long usageCode;
     @JsonFormat(pattern = "yyyy-MM-dd hh:mm:ss")
+    @LastModifiedDate
     private LocalDateTime usageDatetime;
     private Long employeeCode; //TODO 수정필
     private Long workOrderCode; //TODO 수정필
     private MaterialUsageStatus status;
+
+    public MaterialUsage(Long workOrderCode, LocalDateTime usageDatetime) {
+        this.workOrderCode = workOrderCode;
+        this.usageDatetime = usageDatetime;
+        this.status = MaterialUsageStatus.READY;
+    }
+
+    public static MaterialUsage of(Long workOrderCode, LocalDate workOrderDate) {
+        return new MaterialUsage(
+                workOrderCode, workOrderDate.atStartOfDay()
+        );
+    }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/domain/entity/material/StockUsage.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/domain/entity/material/StockUsage.java
@@ -1,5 +1,6 @@
 package com.hmdandelion.project_1410002.production.domain.entity.material;
 
+import com.hmdandelion.project_1410002.production.dto.material.request.StockUsageCreateRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,8 +17,23 @@ public class StockUsage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long stockUsageCode;
-    private int usedQuantity;
+    private long usedQuantity;
     private Long stockCode;
     private Long usageCode;
     private boolean transmissionStatus;
+
+    public StockUsage(long usedQuantity, Long stockCode, Long usageCode) {
+        this.usedQuantity = usedQuantity;
+        this.stockCode = stockCode;
+        this.usageCode = usageCode;
+        this.transmissionStatus = false;
+    }
+
+    public static StockUsage from(StockUsageCreateRequest request) {
+        return new StockUsage(
+                request.getUsedQuantity(),
+                request.getStockCode(),
+                request.getUsageCode()
+        );
+    }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/domain/entity/material/StockUsage.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/domain/entity/material/StockUsage.java
@@ -36,4 +36,8 @@ public class StockUsage {
                 request.getUsageCode()
         );
     }
+
+    public void changeTransmission() {
+        this.transmissionStatus = !this.transmissionStatus;
+    }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/domain/repository/line/LineRepo.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/domain/repository/line/LineRepo.java
@@ -12,5 +12,5 @@ public interface LineRepo extends JpaRepository<Line, Long> {
     Page<Line> findByLineStatusNot(LineStatusType lineStatusType, Pageable pageable);
 
 
-    Optional<Object> findLineByLineCode(Long lineCode);
+    Optional<Line> findLineByLineCode(Long lineCode);
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/domain/repository/material/MaterialUsageRepo.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/domain/repository/material/MaterialUsageRepo.java
@@ -3,5 +3,5 @@ package com.hmdandelion.project_1410002.production.domain.repository.material;
 import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MaterialUsageRepo extends JpaRepository<MaterialUsage, Long> {
+public interface MaterialUsageRepo extends JpaRepository<MaterialUsage, Long>, MaterialUsageRepoCustom {
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/domain/repository/material/MaterialUsageRepoCustom.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/domain/repository/material/MaterialUsageRepoCustom.java
@@ -1,0 +1,13 @@
+package com.hmdandelion.project_1410002.production.domain.repository.material;
+
+import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
+import com.hmdandelion.project_1410002.production.dto.material.MaterialUsageDTO;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MaterialUsageRepoCustom  {
+
+    List<MaterialUsageDTO> searchUse(Pageable pageable, List<Long> stockCodes, String sortType);
+}

--- a/src/main/java/com/hmdandelion/project_1410002/production/domain/repository/material/MaterialUsageRepoCustom.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/domain/repository/material/MaterialUsageRepoCustom.java
@@ -2,6 +2,7 @@ package com.hmdandelion.project_1410002.production.domain.repository.material;
 
 import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
 import com.hmdandelion.project_1410002.production.dto.material.MaterialUsageDTO;
+import com.hmdandelion.project_1410002.production.dto.material.response.MaterialUsageResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ import java.util.List;
 public interface MaterialUsageRepoCustom  {
 
     List<MaterialUsageDTO> searchUse(Pageable pageable, List<Long> stockCodes, String sortType);
+
+    MaterialUsageResponse getMaterialUsage(Long usageCode);
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/domain/repository/material/MaterialUsageRepoCustomImpl.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/domain/repository/material/MaterialUsageRepoCustomImpl.java
@@ -1,0 +1,56 @@
+package com.hmdandelion.project_1410002.production.domain.repository.material;
+
+import com.hmdandelion.project_1410002.production.domain.entity.QWorkOrder;
+import com.hmdandelion.project_1410002.production.domain.entity.line.QLine;
+import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
+import com.hmdandelion.project_1410002.production.domain.entity.material.QStockUsage;
+import com.hmdandelion.project_1410002.production.domain.entity.material.StockUsage;
+import com.hmdandelion.project_1410002.production.domain.type.MaterialUsageStatus;
+import com.hmdandelion.project_1410002.production.dto.material.MaterialUsageDTO;
+import com.hmdandelion.project_1410002.production.dto.material.StockUsageDTO;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.hmdandelion.project_1410002.inventory.domian.entity.material.QMaterialSpec.materialSpec;
+import static com.hmdandelion.project_1410002.production.domain.entity.material.QMaterialUsage.materialUsage;
+import static com.hmdandelion.project_1410002.production.domain.entity.material.QStockUsage.stockUsage;
+
+@RequiredArgsConstructor
+public class MaterialUsageRepoCustomImpl implements MaterialUsageRepoCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MaterialUsageDTO> searchUse(Pageable pageable, List<Long> stockCodes, String sortType) {
+        BooleanBuilder builder = new BooleanBuilder();
+        List<Long> targetCodes;
+        if (!stockCodes.isEmpty()) {
+            //재고-사용 리스트 도출
+            targetCodes = queryFactory
+                    .select(stockUsage.usageCode)
+                    .from(stockUsage)
+                    .where(stockUsage.stockCode.in(stockCodes))
+                    .fetch();
+            builder.and(materialUsage.usageCode.in(targetCodes));
+        }
+        if (sortType.equals("not_complete")) {
+            builder.and(materialUsage.status.ne(MaterialUsageStatus.COMPLETED));
+        } else {
+            builder.and(materialUsage.status.eq(MaterialUsageStatus.COMPLETED));
+        }
+
+        List<MaterialUsage> usages = queryFactory
+                .select(materialUsage)
+                .from(materialUsage)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return usages.stream().map(MaterialUsageDTO::from).toList();
+    }
+}

--- a/src/main/java/com/hmdandelion/project_1410002/production/domain/repository/material/StockUsageRepo.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/domain/repository/material/StockUsageRepo.java
@@ -1,0 +1,11 @@
+package com.hmdandelion.project_1410002.production.domain.repository.material;
+
+import com.hmdandelion.project_1410002.production.domain.entity.material.StockUsage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StockUsageRepo extends JpaRepository<StockUsage,Long> {
+
+    List<StockUsage> findAllByUsageCode(Long usageCode);
+}

--- a/src/main/java/com/hmdandelion/project_1410002/production/dto/material/MaterialUsageDTO.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/dto/material/MaterialUsageDTO.java
@@ -2,6 +2,8 @@ package com.hmdandelion.project_1410002.production.dto.material;
 
 import com.hmdandelion.project_1410002.inventory.domian.entity.material.MaterialSpec;
 import com.hmdandelion.project_1410002.inventory.dto.material.dto.MaterialSpecDTO;
+import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
+import com.hmdandelion.project_1410002.production.domain.entity.material.StockUsage;
 import com.hmdandelion.project_1410002.production.domain.type.MaterialUsageStatus;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -10,15 +12,37 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class MaterialUsageDTO {
     private final Long usageCode;
-    private final String lineName;
+    private final Long lineCode;
+    private String lineName;
     private final List<StockUsageDTO> stockUsages;
     private final LocalDateTime usageDatetime;
     @Enumerated(value = EnumType.STRING)
     private final MaterialUsageStatus status;
+    private final Long workOrderCode;
+
+    public static MaterialUsageDTO from(MaterialUsage usage) {
+        return new MaterialUsageDTO(
+                usage.getUsageCode(),
+                usage.getWorkOrder().getLineCode(),
+                new ArrayList<>(),
+                usage.getUsageDatetime(),
+                usage.getStatus(),
+                usage.getWorkOrder().getWorkOrderCode()
+        );
+    }
+
+    public void addLinName(String lineName) {
+        this.lineName = lineName;
+    }
+
+    public void addStockUsages(List<StockUsageDTO> list) {
+        this.stockUsages.addAll(list);
+    }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/dto/material/MaterialUsageDTO.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/dto/material/MaterialUsageDTO.java
@@ -1,9 +1,6 @@
 package com.hmdandelion.project_1410002.production.dto.material;
 
-import com.hmdandelion.project_1410002.inventory.domian.entity.material.MaterialSpec;
-import com.hmdandelion.project_1410002.inventory.dto.material.dto.MaterialSpecDTO;
 import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
-import com.hmdandelion.project_1410002.production.domain.entity.material.StockUsage;
 import com.hmdandelion.project_1410002.production.domain.type.MaterialUsageStatus;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -38,7 +35,7 @@ public class MaterialUsageDTO {
         );
     }
 
-    public void addLinName(String lineName) {
+    public void addLineName(String lineName) {
         this.lineName = lineName;
     }
 

--- a/src/main/java/com/hmdandelion/project_1410002/production/dto/material/StockUsageDTO.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/dto/material/StockUsageDTO.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 public class StockUsageDTO {
     private final Long stockUsageCode;
     private final boolean transmissionStatus;
-    private final int usedQuantity;
+    private final long usedQuantity;
     private final String materialName;
 
     public static StockUsageDTO from(StockUsage stockUsage,String materialName) {

--- a/src/main/java/com/hmdandelion/project_1410002/production/dto/material/StockUsageDTO.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/dto/material/StockUsageDTO.java
@@ -1,5 +1,6 @@
 package com.hmdandelion.project_1410002.production.dto.material;
 
+import com.hmdandelion.project_1410002.production.domain.entity.material.StockUsage;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class StockUsageDTO {
     private final Long stockUsageCode;
+    private final boolean transmissionStatus;
     private final int usedQuantity;
     private final String materialName;
+
+    public static StockUsageDTO from(StockUsage stockUsage,String materialName) {
+        return new StockUsageDTO(
+                stockUsage.getStockUsageCode(),
+                stockUsage.isTransmissionStatus(),
+                stockUsage.getUsedQuantity(),
+                materialName
+        );
+    }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/dto/material/request/StockUsageCreateRequest.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/dto/material/request/StockUsageCreateRequest.java
@@ -1,0 +1,17 @@
+package com.hmdandelion.project_1410002.production.dto.material.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class StockUsageCreateRequest {
+    @NotBlank
+    private final Long stockCode;
+    @NotBlank
+    private final Long usageCode;
+    @Min(value = 1)
+    private final Long usedQuantity;
+}

--- a/src/main/java/com/hmdandelion/project_1410002/production/dto/material/response/MaterialUsageResponse.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/dto/material/response/MaterialUsageResponse.java
@@ -20,6 +20,7 @@ public class MaterialUsageResponse {
     private final Long usageCode;
     private final LocalDateTime usageDatetime;
     private final MaterialUsageStatus status;
+    private final Long orderedQuantity;
 
 
     private final String employeeName;
@@ -37,17 +38,18 @@ public class MaterialUsageResponse {
                                            String positionName,
                                            String departmentName,
                                            String phone,
-                                           Line line,
+                                           String lineName,
                                            List<Bom> boms) {
         return new MaterialUsageResponse(
                 usage.getUsageCode(),
                 usage.getUsageDatetime(),
                 usage.getStatus(),
+                (long) usage.getWorkOrder().getOrderedQuantity(),
                 employeeName,
                 positionName,
                 departmentName,
                 phone,
-                line.getLineName(),
+                lineName,
                 boms.stream().map(BomDTO::from).toList()
         );
     }

--- a/src/main/java/com/hmdandelion/project_1410002/production/dto/material/response/MaterialUsageResponse.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/dto/material/response/MaterialUsageResponse.java
@@ -1,0 +1,46 @@
+package com.hmdandelion.project_1410002.production.dto.material.response;
+
+import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
+import com.hmdandelion.project_1410002.production.domain.type.MaterialUsageStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MaterialUsageResponse {
+    //사용
+    //사용코드
+    //사용일자
+    //사용상태
+    private final Long usageCode;
+    private final LocalDateTime usageDatetime;
+    private MaterialUsageStatus status;
+
+    //사원 - 사용의 employeeCode
+    //이름
+    //부서명
+    //직책명
+    //연락처
+    private final String employeeName;
+    private final String positionName;
+    private final String departmentName;
+    private final String phone;
+
+    //라인 - 사용의 workOrder.lineCode -> 라인의 name
+    //라인코드
+    //라인명
+    private final String lineName;
+
+    //BOM : List - 사용의 workOrder.product.productCode -> BOM정보
+    //스펙코드
+    //자재명
+    //분류명
+    private final Long specCode;
+    private final String materialName;
+    private final String categoryName;
+    private final long quantity;
+
+}

--- a/src/main/java/com/hmdandelion/project_1410002/production/dto/material/response/MaterialUsageResponse.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/dto/material/response/MaterialUsageResponse.java
@@ -1,5 +1,8 @@
 package com.hmdandelion.project_1410002.production.dto.material.response;
 
+import com.hmdandelion.project_1410002.inventory.domian.entity.product.Bom;
+import com.hmdandelion.project_1410002.inventory.dto.product.dto.BomDTO;
+import com.hmdandelion.project_1410002.production.domain.entity.line.Line;
 import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
 import com.hmdandelion.project_1410002.production.domain.type.MaterialUsageStatus;
 import lombok.AccessLevel;
@@ -7,40 +10,46 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class MaterialUsageResponse {
-    //사용
-    //사용코드
-    //사용일자
-    //사용상태
+
+
     private final Long usageCode;
     private final LocalDateTime usageDatetime;
-    private MaterialUsageStatus status;
+    private final MaterialUsageStatus status;
 
-    //사원 - 사용의 employeeCode
-    //이름
-    //부서명
-    //직책명
-    //연락처
+
     private final String employeeName;
     private final String positionName;
     private final String departmentName;
     private final String phone;
 
-    //라인 - 사용의 workOrder.lineCode -> 라인의 name
-    //라인코드
-    //라인명
+
     private final String lineName;
 
-    //BOM : List - 사용의 workOrder.product.productCode -> BOM정보
-    //스펙코드
-    //자재명
-    //분류명
-    private final Long specCode;
-    private final String materialName;
-    private final String categoryName;
-    private final long quantity;
+    private final List<BomDTO> boms;
+
+    public static MaterialUsageResponse of(MaterialUsage usage,
+                                           String employeeName,
+                                           String positionName,
+                                           String departmentName,
+                                           String phone,
+                                           Line line,
+                                           List<Bom> boms) {
+        return new MaterialUsageResponse(
+                usage.getUsageCode(),
+                usage.getUsageDatetime(),
+                usage.getStatus(),
+                employeeName,
+                positionName,
+                departmentName,
+                phone,
+                line.getLineName(),
+                boms.stream().map(BomDTO::from).toList()
+        );
+    }
 
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/dto/material/response/MaterialUsageResponse.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/dto/material/response/MaterialUsageResponse.java
@@ -1,5 +1,6 @@
 package com.hmdandelion.project_1410002.production.dto.material.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.hmdandelion.project_1410002.inventory.domian.entity.product.Bom;
 import com.hmdandelion.project_1410002.inventory.dto.product.dto.BomDTO;
 import com.hmdandelion.project_1410002.production.domain.entity.line.Line;
@@ -18,6 +19,7 @@ public class MaterialUsageResponse {
 
 
     private final Long usageCode;
+    @JsonFormat(pattern = "yyyy-MM-dd hh:mm:ss")
     private final LocalDateTime usageDatetime;
     private final MaterialUsageStatus status;
     private final Long orderedQuantity;

--- a/src/main/java/com/hmdandelion/project_1410002/production/presentation/MaterialUsageController.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/presentation/MaterialUsageController.java
@@ -22,5 +22,5 @@ public class MaterialUsageController {
 
     private final MaterialUsageService materialUsageService;
 
-    //
+    //사용 조회
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/presentation/MaterialUsageController.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/presentation/MaterialUsageController.java
@@ -3,6 +3,7 @@ package com.hmdandelion.project_1410002.production.presentation;
 import com.hmdandelion.project_1410002.common.paging.Pagination;
 import com.hmdandelion.project_1410002.common.paging.PagingButtonInfo;
 import com.hmdandelion.project_1410002.common.paging.PagingResponse;
+import com.hmdandelion.project_1410002.employee.domain.entity.Employee;
 import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
 import com.hmdandelion.project_1410002.production.dto.material.MaterialUsageDTO;
 import com.hmdandelion.project_1410002.production.dto.material.response.MaterialUsageResponse;

--- a/src/main/java/com/hmdandelion/project_1410002/production/presentation/MaterialUsageController.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/presentation/MaterialUsageController.java
@@ -1,17 +1,19 @@
 package com.hmdandelion.project_1410002.production.presentation;
 
 import com.hmdandelion.project_1410002.common.paging.Pagination;
+import com.hmdandelion.project_1410002.common.paging.PagingButtonInfo;
 import com.hmdandelion.project_1410002.common.paging.PagingResponse;
+import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
 import com.hmdandelion.project_1410002.production.dto.material.MaterialUsageDTO;
+import com.hmdandelion.project_1410002.production.dto.material.response.MaterialUsageResponse;
 import com.hmdandelion.project_1410002.production.service.MaterialUsageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,4 +25,27 @@ public class MaterialUsageController {
     private final MaterialUsageService materialUsageService;
 
     //사용 조회
+    @GetMapping("/use")
+    public ResponseEntity<PagingResponse> searchUse(
+            @RequestParam(defaultValue = "1") final int page,
+            @RequestParam(required = false) String materialName,
+            @RequestParam(defaultValue = "not_complete") String sortType
+    ) {
+        Pageable pageable = PageRequest.of(page - 1, 10);
+        List<MaterialUsageDTO> list = materialUsageService.searchUse(pageable, materialName, sortType);
+        Page<MaterialUsageDTO> toPage = new PageImpl<>(list, pageable, list.size());
+
+        PagingButtonInfo pagingButtonInfo = Pagination.getPagingButtonInfo(toPage);
+        PagingResponse res = new PagingResponse(list, pagingButtonInfo);
+
+        return ResponseEntity.ok(res);
+    }
+
+    //상세조회
+    @GetMapping("/use/{usageCode}")
+    public ResponseEntity<MaterialUsageResponse> getUse(
+            @PathVariable final Long usageCode
+    ) {
+
+    }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/presentation/MaterialUsageController.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/presentation/MaterialUsageController.java
@@ -46,6 +46,8 @@ public class MaterialUsageController {
     public ResponseEntity<MaterialUsageResponse> getUse(
             @PathVariable final Long usageCode
     ) {
+        final MaterialUsageResponse res = materialUsageService.findOne(usageCode);
 
+        return ResponseEntity.ok(res);
     }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/presentation/StockUsageController.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/presentation/StockUsageController.java
@@ -1,0 +1,43 @@
+package com.hmdandelion.project_1410002.production.presentation;
+
+import com.hmdandelion.project_1410002.common.paging.Pagination;
+import com.hmdandelion.project_1410002.common.paging.PagingResponse;
+import com.hmdandelion.project_1410002.production.dto.material.StockUsageDTO;
+import com.hmdandelion.project_1410002.production.dto.material.request.StockUsageCreateRequest;
+import com.hmdandelion.project_1410002.production.service.StockUsageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/material")
+public class StockUsageController {
+
+    private final StockUsageService stockUsageService;
+
+    //사용코드로 목록조회
+    @GetMapping("/stock-usage/{usageCode}")
+    public ResponseEntity<PagingResponse> getStockUsageList(
+            @PathVariable final Long usageCode
+    ) {
+        List<StockUsageDTO> list = stockUsageService.findByUsageCode(usageCode);
+        PagingResponse response = PagingResponse.of(list, null);
+        return ResponseEntity.ok(response);
+    }
+
+
+    //전달목록으로 재고 등록
+    @PostMapping("/stock-usage")
+    public ResponseEntity<Void> createStockUsage(
+            @RequestBody StockUsageCreateRequest request
+    ) {
+        stockUsageService.createStockUsage(request);
+        return ResponseEntity.created(URI.create("api/v1/material/use/" + request.getUsageCode())).build();
+    }
+}

--- a/src/main/java/com/hmdandelion/project_1410002/production/presentation/StockUsageController.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/presentation/StockUsageController.java
@@ -52,8 +52,12 @@ public class StockUsageController {
 
     //전달여부 변경
     @PutMapping("/stock-usage")
-    public ResponseEntity<Void> changeTransmission() {
+    public ResponseEntity<Void> changeTransmission(
+            @RequestParam final Long stockUsageCode
+    ) {
+        final Long usageCode = stockUsageService.changeTransmission(stockUsageCode);
 
+        return ResponseEntity.created(URI.create("/api/v1/material/use/" + usageCode)).build();
     }
 
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/presentation/StockUsageController.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/presentation/StockUsageController.java
@@ -42,11 +42,18 @@ public class StockUsageController {
     }
 
     //전달취소
-    @DeleteMapping("/stok-usage")
+    @DeleteMapping("/stock-usage")
     public ResponseEntity<Void> deleteStockUsage(
             @RequestParam final Long stockUsageCode
     ) {
         stockUsageService.deleteById(stockUsageCode);
         return ResponseEntity.noContent().build();
     }
+
+    //전달여부 변경
+    @PutMapping("/stock-usage")
+    public ResponseEntity<Void> changeTransmission() {
+
+    }
+
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/presentation/StockUsageController.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/presentation/StockUsageController.java
@@ -40,4 +40,13 @@ public class StockUsageController {
         stockUsageService.createStockUsage(request);
         return ResponseEntity.created(URI.create("api/v1/material/use/" + request.getUsageCode())).build();
     }
+
+    //전달취소
+    @DeleteMapping("/stok-usage")
+    public ResponseEntity<Void> deleteStockUsage(
+            @RequestParam final Long stockUsageCode
+    ) {
+        stockUsageService.deleteById(stockUsageCode);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/LineService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/LineService.java
@@ -54,7 +54,7 @@ public class LineService {
     @Transactional
     public void modify(Long lineCode, LineUpdateRequest lineUpdateRequest) {
 
-        Line line = (Line) lineRepo.findLineByLineCode(lineCode)
+        Line line = lineRepo.findLineByLineCode(lineCode)
                 .orElseThrow(() -> new NotFoundException(ExceptionCode.NOT_FOUND_LINE_CODE));
 
         line.modify(
@@ -69,6 +69,11 @@ public class LineService {
     public void remove(Long lineCode) {
 
         lineRepo.deleteById(lineCode);
+    }
+
+    public String findNameByCode(Long lineCode) {
+        return lineRepo.findLineByLineCode(lineCode)
+                            .orElseThrow(() -> new NotFoundException(ExceptionCode.NOT_FOUND_LINE_CODE)).getLineName();
     }
 }
 

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/MaterialUsageService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/MaterialUsageService.java
@@ -1,7 +1,22 @@
 package com.hmdandelion.project_1410002.production.service;
 
+import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
+import com.hmdandelion.project_1410002.production.domain.repository.material.MaterialUsageRepo;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @Service
+@RequiredArgsConstructor
 public class MaterialUsageService {
+
+    private final MaterialUsageRepo materialUsageRepo;
+
+    public void usageCreate(Long workOrderCode, LocalDate workOrderDate) {
+        MaterialUsage createOne = MaterialUsage.of(workOrderCode, workOrderDate);
+        materialUsageRepo.save(createOne);
+    }
+
+
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/MaterialUsageService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/MaterialUsageService.java
@@ -1,22 +1,52 @@
 package com.hmdandelion.project_1410002.production.service;
 
+import com.hmdandelion.project_1410002.common.exception.NoContentsException;
+import com.hmdandelion.project_1410002.common.exception.type.ExceptionCode;
+import com.hmdandelion.project_1410002.inventory.service.MaterialStockService;
+import com.hmdandelion.project_1410002.production.domain.entity.WorkOrder;
 import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
 import com.hmdandelion.project_1410002.production.domain.repository.material.MaterialUsageRepo;
+import com.hmdandelion.project_1410002.production.dto.material.MaterialUsageDTO;
+import com.hmdandelion.project_1410002.production.dto.material.StockUsageDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MaterialUsageService {
 
     private final MaterialUsageRepo materialUsageRepo;
+    private final MaterialStockService materialStockService;
+    private final StockUsageService stockUsageService;
+    private final LineService lineService;
 
-    public void usageCreate(Long workOrderCode, LocalDate workOrderDate) {
-        MaterialUsage createOne = MaterialUsage.of(workOrderCode, workOrderDate);
+
+    public void usageCreate(WorkOrder workOrder) {
+        MaterialUsage createOne = MaterialUsage.of(workOrder);
         materialUsageRepo.save(createOne);
     }
 
 
+    public List<MaterialUsageDTO> searchUse(Pageable pageable, String materialName, String sortType) {
+        List<Long> stockCodes = new ArrayList<>();
+        if (materialName != null) {
+            stockCodes = materialStockService.searchMaterialStockByMaterialName(materialName);
+        }
+
+        List<MaterialUsageDTO> list = materialUsageRepo.searchUse(pageable, stockCodes, sortType);
+        if (list.isEmpty()) {
+            throw new NoContentsException(ExceptionCode.NO_CONTENTS_MATERIAL_USE);
+        }
+        for (MaterialUsageDTO dto : list) {
+            List<StockUsageDTO> stockUsages = stockUsageService.findByUsageCode(dto.getUsageCode());
+            dto.addStockUsages(stockUsages);
+            dto.addLinName(lineService.findNameByCode(dto.getLineCode()));
+        }
+        return list;
+    }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/MaterialUsageService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/MaterialUsageService.java
@@ -1,9 +1,7 @@
 package com.hmdandelion.project_1410002.production.service;
 
 import com.hmdandelion.project_1410002.common.exception.NoContentsException;
-import com.hmdandelion.project_1410002.common.exception.NotFoundException;
 import com.hmdandelion.project_1410002.common.exception.type.ExceptionCode;
-import com.hmdandelion.project_1410002.employee.domain.entity.Employee;
 import com.hmdandelion.project_1410002.inventory.service.MaterialStockService;
 import com.hmdandelion.project_1410002.production.domain.entity.WorkOrder;
 import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
@@ -15,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,7 +45,7 @@ public class MaterialUsageService {
         for (MaterialUsageDTO dto : list) {
             List<StockUsageDTO> stockUsages = stockUsageService.findByUsageCode(dto.getUsageCode());
             dto.addStockUsages(stockUsages);
-            dto.addLinName(lineService.findNameByCode(dto.getLineCode()));
+            dto.addLineName(lineService.findNameByCode(dto.getLineCode()));
         }
         return list;
     }

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/MaterialUsageService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/MaterialUsageService.java
@@ -3,6 +3,7 @@ package com.hmdandelion.project_1410002.production.service;
 import com.hmdandelion.project_1410002.common.exception.NoContentsException;
 import com.hmdandelion.project_1410002.common.exception.NotFoundException;
 import com.hmdandelion.project_1410002.common.exception.type.ExceptionCode;
+import com.hmdandelion.project_1410002.employee.domain.entity.Employee;
 import com.hmdandelion.project_1410002.inventory.service.MaterialStockService;
 import com.hmdandelion.project_1410002.production.domain.entity.WorkOrder;
 import com.hmdandelion.project_1410002.production.domain.entity.material.MaterialUsage;
@@ -53,9 +54,7 @@ public class MaterialUsageService {
     }
 
     public MaterialUsageResponse findOne(Long usageCode) {
-        final MaterialUsage materialUsage = materialUsageRepo.findById(usageCode).orElseThrow(
-                () -> new NotFoundException(ExceptionCode.NOT_FOUND_USAGE_CODE)
-        );
-        return null;
+
+        return materialUsageRepo.getMaterialUsage(usageCode);
     }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/MaterialUsageService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/MaterialUsageService.java
@@ -1,6 +1,7 @@
 package com.hmdandelion.project_1410002.production.service;
 
 import com.hmdandelion.project_1410002.common.exception.NoContentsException;
+import com.hmdandelion.project_1410002.common.exception.NotFoundException;
 import com.hmdandelion.project_1410002.common.exception.type.ExceptionCode;
 import com.hmdandelion.project_1410002.inventory.service.MaterialStockService;
 import com.hmdandelion.project_1410002.production.domain.entity.WorkOrder;
@@ -8,6 +9,7 @@ import com.hmdandelion.project_1410002.production.domain.entity.material.Materia
 import com.hmdandelion.project_1410002.production.domain.repository.material.MaterialUsageRepo;
 import com.hmdandelion.project_1410002.production.dto.material.MaterialUsageDTO;
 import com.hmdandelion.project_1410002.production.dto.material.StockUsageDTO;
+import com.hmdandelion.project_1410002.production.dto.material.response.MaterialUsageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -48,5 +50,12 @@ public class MaterialUsageService {
             dto.addLinName(lineService.findNameByCode(dto.getLineCode()));
         }
         return list;
+    }
+
+    public MaterialUsageResponse findOne(Long usageCode) {
+        final MaterialUsage materialUsage = materialUsageRepo.findById(usageCode).orElseThrow(
+                () -> new NotFoundException(ExceptionCode.NOT_FOUND_USAGE_CODE)
+        );
+        return null;
     }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/StockUsageService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/StockUsageService.java
@@ -1,5 +1,7 @@
 package com.hmdandelion.project_1410002.production.service;
 
+import com.hmdandelion.project_1410002.common.exception.NotFoundException;
+import com.hmdandelion.project_1410002.common.exception.type.ExceptionCode;
 import com.hmdandelion.project_1410002.inventory.domian.entity.material.MaterialStock;
 import com.hmdandelion.project_1410002.inventory.dto.material.request.MaterialStockModifyRequest;
 import com.hmdandelion.project_1410002.inventory.service.MaterialSpecService;
@@ -37,18 +39,18 @@ public class StockUsageService {
     public void createStockUsage(StockUsageCreateRequest request) {
         StockUsage newStockUsage = StockUsage.from(request);
         stockUsageRepo.save(newStockUsage);
-        MaterialStockModifyRequest stockRequest = new MaterialStockModifyRequest(
-                request.getStockCode(),
-                null,
-                -request.getUsedQuantity().intValue(),
-                LocalDateTime.now(),
-                "자재 사용으로 수정됨.(System)"
-        );
-        materialStockService.modify(stockRequest);
+        materialStockService.modifyWithStockUsage(newStockUsage.getStockCode(),(int) newStockUsage.getUsedQuantity(),
+                                                  "자재 사용 취소로 수정됨.(System)");
     }
 
     @Transactional
     public void deleteById(Long stockUsageCode) {
+        StockUsage stockUsage = stockUsageRepo.findById(stockUsageCode).orElseThrow(
+                () -> new NotFoundException(ExceptionCode.NOT_FOUND_USAGE_CODE)
+        );
+        materialStockService.modifyWithStockUsage(stockUsage.getStockCode(),(int) -stockUsage.getUsedQuantity(),
+                                                  "자재 사용 취소로 수정됨.(System)");
+
         stockUsageRepo.deleteById(stockUsageCode);
     }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/StockUsageService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/StockUsageService.java
@@ -1,14 +1,18 @@
 package com.hmdandelion.project_1410002.production.service;
 
 import com.hmdandelion.project_1410002.inventory.domian.entity.material.MaterialStock;
+import com.hmdandelion.project_1410002.inventory.dto.material.request.MaterialStockModifyRequest;
 import com.hmdandelion.project_1410002.inventory.service.MaterialSpecService;
 import com.hmdandelion.project_1410002.inventory.service.MaterialStockService;
 import com.hmdandelion.project_1410002.production.domain.entity.material.StockUsage;
 import com.hmdandelion.project_1410002.production.domain.repository.material.StockUsageRepo;
 import com.hmdandelion.project_1410002.production.dto.material.StockUsageDTO;
+import com.hmdandelion.project_1410002.production.dto.material.request.StockUsageCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,5 +31,19 @@ public class StockUsageService {
             result.add(StockUsageDTO.from(item, MaterialName));
         }
         return result;
+    }
+
+    @Transactional
+    public void createStockUsage(StockUsageCreateRequest request) {
+        StockUsage newStockUsage = StockUsage.from(request);
+        stockUsageRepo.save(newStockUsage);
+        MaterialStockModifyRequest stockRequest = new MaterialStockModifyRequest(
+                request.getStockCode(),
+                null,
+                -request.getUsedQuantity().intValue(),
+                LocalDateTime.now(),
+                "자재 사용으로 수정됨.(System)"
+        );
+        materialStockService.modify(stockRequest);
     }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/StockUsageService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/StockUsageService.java
@@ -1,0 +1,31 @@
+package com.hmdandelion.project_1410002.production.service;
+
+import com.hmdandelion.project_1410002.inventory.domian.entity.material.MaterialStock;
+import com.hmdandelion.project_1410002.inventory.service.MaterialSpecService;
+import com.hmdandelion.project_1410002.inventory.service.MaterialStockService;
+import com.hmdandelion.project_1410002.production.domain.entity.material.StockUsage;
+import com.hmdandelion.project_1410002.production.domain.repository.material.StockUsageRepo;
+import com.hmdandelion.project_1410002.production.dto.material.StockUsageDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockUsageService {
+
+    private final StockUsageRepo stockUsageRepo;
+    private final MaterialStockService materialStockService;
+
+    public List<StockUsageDTO> findByUsageCode(Long usageCode) {
+        List<StockUsage> list = stockUsageRepo.findAllByUsageCode(usageCode);
+        List<StockUsageDTO> result = new ArrayList<>();
+        for (StockUsage item : list) {
+            String MaterialName = materialStockService.findById(item.getStockCode()).getSpec().getMaterialName();
+            result.add(StockUsageDTO.from(item, MaterialName));
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/StockUsageService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/StockUsageService.java
@@ -53,4 +53,14 @@ public class StockUsageService {
 
         stockUsageRepo.deleteById(stockUsageCode);
     }
+
+    @Transactional
+    public Long changeTransmission(Long stockUsageCode) {
+        StockUsage stockUsage =  stockUsageRepo.findById(stockUsageCode).orElseThrow(
+                () -> new NotFoundException(ExceptionCode.NOT_FOUND_USAGE_CODE)
+        );
+        stockUsage.changeTransmission();
+
+        return stockUsage.getUsageCode();
+    }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/StockUsageService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/StockUsageService.java
@@ -46,4 +46,9 @@ public class StockUsageService {
         );
         materialStockService.modify(stockRequest);
     }
+
+    @Transactional
+    public void deleteById(Long stockUsageCode) {
+        stockUsageRepo.deleteById(stockUsageCode);
+    }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/WorkOrderService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/WorkOrderService.java
@@ -30,7 +30,6 @@ public class WorkOrderService {
 
     private final WorkOrderRepo workOrderRepo;
 
-    private final ProductService productService;
     private final MaterialUsageService materialUsageService;
 
 //    private final EmployeeService employeeService;
@@ -88,7 +87,7 @@ public class WorkOrderService {
         );
 
         final WorkOrder workOrder = workOrderRepo.save(newWorkOrder);
-        materialUsageService.usageCreate(workOrder.getWorkOrderCode(), workOrder.getWorkOrderDate());
+        materialUsageService.usageCreate(workOrder);
 
         return workOrder.getWorkOrderCode();
     }
@@ -129,5 +128,11 @@ public class WorkOrderService {
             // 작업이 없는 경우 수정할 수 없음을 알림
             throw new NotFoundException(ExceptionCode.NOT_FOUND_WORK_ORDER);
         }
+    }
+
+    public Long findLineCodeById(Long workOrderCode) {
+        final WorkOrder workOrder = workOrderRepo.findByWorkOrderCode(workOrderCode)
+                                           .orElseThrow(() -> new NotFoundException(ExceptionCode.NOT_FOUND_WORK_ORDER));
+        return workOrder.getLineCode();
     }
 }

--- a/src/main/java/com/hmdandelion/project_1410002/production/service/WorkOrderService.java
+++ b/src/main/java/com/hmdandelion/project_1410002/production/service/WorkOrderService.java
@@ -31,6 +31,7 @@ public class WorkOrderService {
     private final WorkOrderRepo workOrderRepo;
 
     private final ProductService productService;
+    private final MaterialUsageService materialUsageService;
 
 //    private final EmployeeService employeeService;
 //
@@ -87,6 +88,7 @@ public class WorkOrderService {
         );
 
         final WorkOrder workOrder = workOrderRepo.save(newWorkOrder);
+        materialUsageService.usageCreate(workOrder.getWorkOrderCode(), workOrder.getWorkOrderDate());
 
         return workOrder.getWorkOrderCode();
     }


### PR DESCRIPTION
---
name: 원자재 사용관리
about: 원자재 사용시에 필요한 기능
title: ''
labels: PR
assignees: ''

---

## 변경 내용

- 작업지시서 등록시 원자재 사용이 자동으로 등록
- 사용의 전체조회
- 특정 사용의 상세조회
- 재고-사용의 추가
- 재고-사용목록의 조회
- 재고-사용 삭제
- 재고-사용 특정정보 변경

## 관련 이슈

- #27
- #55 라인 이름을 알아오는 로직 몇가지 추가

## 변경 사항 확인 방법

- 프로젝트 최상위/httpTest/MaterialUsageTest의 각 항목들 실행하여 확인
